### PR TITLE
Shulker boxes now correctly added as unstackable

### DIFF
--- a/data/taglib/tags/items/unstackable.json
+++ b/data/taglib/tags/items/unstackable.json
@@ -10,6 +10,7 @@
         "#taglib:potions",
         "#taglib:horse_armor",
         "#taglib:minecarts",
+        "#taglib:shulker_boxes",
         "#taglib:unstackable_tools",
         "#taglib:unstackable_foods",
         "#taglib:unstackable_misc",

--- a/data/taglib/tags/items/unstackable_misc.json
+++ b/data/taglib/tags/items/unstackable_misc.json
@@ -3,7 +3,6 @@
     "values": [
         "minecraft:shield",
         "minecraft:totem_of_undying",
-        "minecraft:shulker_box",
         "minecraft:elytra",
         "minecraft:enchanted_book",
         "minecraft:writable_book"


### PR DESCRIPTION
Made a mistake in the last PR, this now correctly adds shulker boxes as unstackable.