### PR TITLE
Add tag for items that stack to 16 (aka. quarter stackables)

### DIFF
--- a/data/taglib/tags/items/quarter_stackable.json
+++ b/data/taglib/tags/items/quarter_stackable.json
@@ -1,0 +1,13 @@
+{
+  "replace": false,
+  "values": [
+      "#minecraft:banners",
+      "#minecraft:signs",
+      "minecraft:written_book",
+      "minecraft:honey_bottle",
+      "minecraft:snowball",
+      "minecraft:egg",
+      "minecraft:ender_pearl",
+      "minecraft:armor_stand"
+  ]
+}


### PR DESCRIPTION
Fairly small addition. Single tag, just with the couple of items that only stack to 16.