### PR TITLE
Add moss carpet to walk_through.json

### DIFF
--- a/data/taglib/tags/block/walk_through.json
+++ b/data/taglib/tags/block/walk_through.json
@@ -79,6 +79,10 @@
 		},
 		{
 			"required": false,
+			"id": "minecraft:moss_carpet"
+		},
+		{
+			"required": false,
 			"id": "#minecraft:signs"
 		},
 		{


### PR DESCRIPTION
Wool carpets are included in there but moss carpet is missing.